### PR TITLE
Upgrade Apache Commons Collections to v3.2.2

### DIFF
--- a/ATB_1.0_src/pom.xml
+++ b/ATB_1.0_src/pom.xml
@@ -32,7 +32,7 @@ See http://ncip.github.com/annotation-and-image-markup/LICENSE.txt for details.
 		<dependency>
 			<groupId>commons-collections</groupId>
 			<artifactId>commons-collections</artifactId>
-			<version>3.2.1</version>
+			<version>3.2.2</version>
 		</dependency>
 
 		<dependency>

--- a/ATB_1.1_src/pom.xml
+++ b/ATB_1.1_src/pom.xml
@@ -33,7 +33,7 @@ See http://ncip.github.com/annotation-and-image-markup/LICENSE.txt for details.
 		<dependency>
 			<groupId>commons-collections</groupId>
 			<artifactId>commons-collections</artifactId>
-			<version>3.2.1</version>
+			<version>3.2.2</version>
 		</dependency>
 
 		<dependency>


### PR DESCRIPTION
Version 3.2.1 has a CVSS 10.0 vulnerability. That is the worst kind of
vulnerability that exists. By merely existing on the classpath, this
library causes the Java serialization parser for the entire JVM process
to go from being a state machine to a turing machine. A turing machine
with an exec() function!

https://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2015-8103
https://commons.apache.org/proper/commons-collections/security-reports.html
http://foxglovesecurity.com/2015/11/06/what-do-weblogic-websphere-jboss-jenkins-opennms-and-your-application-have-in-common-this-vulnerability/
