### PR TITLE
Fix hard-coded XnatUrl settings

### DIFF
--- a/AimPlugin4.5/XnatWebBrowser/XnatWebBrowserTool.cs
+++ b/AimPlugin4.5/XnatWebBrowser/XnatWebBrowserTool.cs
@@ -37,6 +37,7 @@ using ClearCanvas.Common.Utilities;
 using ClearCanvas.Desktop;
 using ClearCanvas.Desktop.Actions;
 using ClearCanvas.Desktop.Tools;
+using XnatWebBrowser.Configuration;
 
 namespace XnatWebBrowser
 {
@@ -92,7 +93,7 @@ namespace XnatWebBrowser
             var component = new XnatWebBrowserComponent();
 
             ApplicationComponent.LaunchAsWorkspace(Context.DesktopWindow, component, SR.WorkspaceName);
-            component.Url = "https://central.xnat.org/";
+            component.Url = XnatSettings.Default.XnatUrl;
             component.SetDocumentTitle("XNAT Imaging");
             component.Go();
             component.Stopped += ComponentStopped;


### PR DESCRIPTION
When we change the url setting in 'Tools->Preferences->XNAT->XNAT URL', the browser will not visit the specified url.
Upon clicking the XNAT button on the top left toolbar, it'll still open a browser linking to the site https://central.xnat.org/

The hard-coded XnatUrl settings is fixed by reading the settings file.

Issue-Id: [224](https://tracker.nci.nih.gov/browse/AIMWS-224)